### PR TITLE
Add helper to remove outer stackup layers

### DIFF
--- a/src/pyedb/dotnet/database/stackup.py
+++ b/src/pyedb/dotnet/database/stackup.py
@@ -910,6 +910,21 @@ class Stackup(LayerCollection):
         self.refresh_layer_collection()
         return True
 
+    def remove_outer_layers(self):
+        """Remove the first and last layers from the stackup.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` if the operation fails due to an insufficient number of layers.
+        """
+        layer_names = list(self.layers.keys())
+        if len(layer_names) < 2:
+            return False
+        self.remove_layer(layer_names[0])
+        self.remove_layer(layer_names[-1])
+        return True
+
     def export(self, fpath, file_format="xml", include_material_with_layer=False):
         """Export stackup definition to a CSV or JSON file.
 

--- a/src/pyedb/grpc/database/stackup.py
+++ b/src/pyedb/grpc/database/stackup.py
@@ -836,6 +836,21 @@ class Stackup(LayerCollection):
         self._pedb.layout.layer_collection = new_layer_collection
         return True
 
+    def remove_outer_layers(self):
+        """Remove the first and last layers from the stackup.
+
+        Returns
+        -------
+        bool
+            ``True`` when successful, ``False`` if the operation fails due to an insufficient number of layers.
+        """
+        layer_names = list(self.layers.keys())
+        if len(layer_names) < 2:
+            return False
+        self.remove_layer(layer_names[0])
+        self.remove_layer(layer_names[-1])
+        return True
+
     def export(self, fpath, file_format="xml", include_material_with_layer=False):
         """Export stackup definition to a file.
 

--- a/tests/grpc/system/test_edb_stackup.py
+++ b/tests/grpc/system/test_edb_stackup.py
@@ -1386,3 +1386,10 @@ class TestClass:
         l_id = edbapp.stackup.layers_by_id.index([base_layer.id, base_layer.name])
         assert edbapp.stackup.layers_by_id[l_id - 1][1] == "add_layer_above"
         edbapp.close()
+
+    def test_remove_outer_layers(self, edb_examples):
+        edbapp = edb_examples.get_si_verse()
+        original_layers = list(edbapp.stackup.layers.keys())
+        assert edbapp.stackup.remove_outer_layers()
+        assert list(edbapp.stackup.layers.keys()) == original_layers[1:-1]
+        edbapp.close()

--- a/tests/legacy/system/test_edb_stackup.py
+++ b/tests/legacy/system/test_edb_stackup.py
@@ -1386,3 +1386,10 @@ class TestClass:
         l_id = edbapp.stackup.layers_by_id.index([base_layer.id, base_layer.name])
         assert edbapp.stackup.layers_by_id[l_id - 1][1] == "add_layer_above"
         edbapp.close()
+
+    def test_remove_outer_layers(self, edb_examples):
+        edbapp = edb_examples.get_si_verse()
+        original_layers = list(edbapp.stackup.layers.keys())
+        assert edbapp.stackup.remove_outer_layers()
+        assert list(edbapp.stackup.layers.keys()) == original_layers[1:-1]
+        edbapp.close()


### PR DESCRIPTION
## Summary
- add `remove_outer_layers` to Stackup classes
- test removing outer layers in legacy and gRPC APIs

## Testing
- `pre-commit` *(fails: `pre-commit: command not found`)*
- `pytest -k stackup` *(fails: `pytest: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_684a29e0b118832aa46a10866faa59af